### PR TITLE
Fix landing page URL

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -36,5 +36,9 @@ urlpatterns = [
     path("", include("transport.urls")),
 
     # Landing page pública (index)
-    path("", TemplateView.as_view(template_name="index.html"), name="home"),
+    path(
+        "index/",
+        TemplateView.as_view(template_name="index.html"),
+        name="index",
+    ),
 ]


### PR DESCRIPTION
## Summary
- give `index.html` its own URL so it doesn't conflict with `transport.urls`

## Testing
- `python manage.py test` *(fails: No module named 'django')*