### PR TITLE
Fix maintenance endpoint

### DIFF
--- a/transport/urls.py
+++ b/transport/urls.py
@@ -56,6 +56,8 @@ router.register(r"pagamentos/agregados", PagamentoAgregadoViewSet, basename="pag
 router.register(r"pagamentos/proprios", PagamentoProprioViewSet, basename="pagamento-proprio")
 router.register(r"faixas-km", FaixaKMViewSet, basename="faixa-km")
 router.register(r"manutencao/painel", ManutencaoPainelViewSet, basename="manutencao-painel")
+# Rota direta para manutenções (além da aninhada em /veiculos/)
+router.register(r"manutencoes", ManutencaoVeiculoViewSet, basename="manutencao-veiculo")
 router.register(r"usuarios", UserViewSet, basename="usuario")
 router.register(r"configuracoes/empresa", ConfiguracaoEmpresaViewSet, basename="configuracao-empresa")
 router.register(r"configuracoes/parametros", ParametroSistemaViewSet, basename="parametros-sistema")


### PR DESCRIPTION
## Summary
- expose direct /api/manutencoes/ routes

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*