### PR TITLE
Fix auth setup and method handling

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -179,8 +179,9 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 # Django REST Framework Settings
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
+        # Use JWT authentication for all API endpoints. SessionAuthentication is
+        # disabled to avoid mixing session based auth with token auth.
         "rest_framework_simplejwt.authentication.JWTAuthentication",
-        "rest_framework.authentication.SessionAuthentication", # For Browsable API
     ),
     "DEFAULT_PERMISSION_CLASSES": (
         # By default, require authentication for all API views.
@@ -261,7 +262,8 @@ SWAGGER_SETTINGS = {
             'description': "Enter 'Bearer <token>'",
         }
     },
-    'USE_SESSION_AUTH': True, # Useful for Browsable API login
+    # With JWT-only authentication we disable session auth in Swagger UI
+    'USE_SESSION_AUTH': False,
     'LOGIN_URL': LOGIN_URL,
     'LOGOUT_URL': '/admin/logout/', # Using admin logout for Swagger UI
     'VALIDATOR_URL': None, # Set to None to disable schema validation errors in UI

--- a/transport/views/auth_views.py
+++ b/transport/views/auth_views.py
@@ -80,4 +80,7 @@ class UserViewSet(viewsets.ModelViewSet):
             serializer.is_valid(raise_exception=True) # Levanta erro se inválido
             serializer.save()
             return Response(serializer.data)
-        # DRF cuida de retornar 405 Method Not Allowed para outros métodos
+        # Para outros métodos, DRF normalmente retornaria 405 automaticamente,
+        # mas explicitamos para evitar comportamentos inesperados.
+        return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)
+


### PR DESCRIPTION
## Summary
- use only JWT auth classes for API
- disable session auth in Swagger
- explicitly return 405 for unsupported methods

## Testing
- `python manage.py check --deploy --fail-level WARNING` *(fails: ModuleNotFoundError: No module named 'django')*