### PR TITLE
Enable detail modals via URL hash

### DIFF
--- a/transport/static/js/cte_panel.js
+++ b/transport/static/js/cte_panel.js
@@ -26,6 +26,7 @@ document.addEventListener('DOMContentLoaded', function() {
     loadCTeList();       // Carrega a lista principal de CT-es com o range padrão
 
     setupEventListeners();
+    openDetailFromHash(); // Abre modal se hash contiver ID
 });
 
 function setupEventListeners() {
@@ -718,6 +719,16 @@ function getChartColors(count) {
 function getChartBorderColors(count) {
      const baseColors = ['#388E3C', '#0f3b2f', '#FFA000', '#1976D2', '#E64A19', '#455A64', '#7B1FA2', '#0097A7', '#689F38', '#C2185B'];
     return Array.from({ length: count }, (_, i) => baseColors[i % baseColors.length]);
+}
+
+// Abre automaticamente o modal de detalhes se a URL contiver '#detalhe-<id>'
+function openDetailFromHash() {
+    const match = window.location.hash.match(/^#detalhe-(\d+)/);
+    if (match) {
+        showCTeDetails(match[1]);
+        // Limpa o hash para evitar repetição ao fechar o modal
+        history.replaceState(null, '', window.location.pathname + window.location.search);
+    }
 }
 
 async function handleFetchResponse(response) {

--- a/transport/static/js/mdfe_panel.js
+++ b/transport/static/js/mdfe_panel.js
@@ -20,6 +20,7 @@ document.addEventListener('DOMContentLoaded', function() {
     setDefaultDateRange();
     loadAllData(); // Carrega dados do painel e a primeira página da lista
     setupEventListeners();
+    openDetailFromHash(); // Abre modal se hash contiver ID
 });
 
 /**
@@ -807,6 +808,15 @@ function showNotification(message, type = 'success', duration = 5000) {
     const toast = new bootstrap.Toast(toastElement, { delay: duration });
     toast.show();
     toastElement.addEventListener('hidden.bs.toast', function() { this.remove(); if (toastContainer.children.length === 0) toastContainer.remove(); });
+}
+
+// Abre automaticamente o modal de detalhes se a URL contiver '#detalhe-<id>'
+function openDetailFromHash() {
+    const match = window.location.hash.match(/^#detalhe-(\d+)/);
+    if (match) {
+        showMDFeDetails(match[1]);
+        history.replaceState(null, '', window.location.pathname + window.location.search);
+    }
 }
 
 // Adicionar o objeto Auth simulado se não estiver globalmente disponível para testes


### PR DESCRIPTION
## Summary
- support opening CT-e and MDF-e detail modals when page loads with `#detalhe-<id>`
- call new helpers in `cte_panel.js` and `mdfe_panel.js`

## Testing
- `python -m django --version` *(fails: No module named django)*