### PR TITLE
Fix maintenance panel indicators

### DIFF
--- a/transport/templates/manutencao.html
+++ b/transport/templates/manutencao.html
@@ -43,7 +43,6 @@
                     <option value="">Todos</option>
                     <option value="PENDENTE">Pendente</option>
                     <option value="AGENDADO">Agendado</option>
-                    <option value="CONCLUIDO">Concluído</option>
                     <option value="PAGO">Pago</option>
                     <option value="CANCELADO">Cancelado</option>
                 </select>
@@ -262,7 +261,6 @@
                             <select class="form-select" id="status_manutencao" name="status">
                                 <option value="PENDENTE">Pendente</option>
                                 <option value="AGENDADO">Agendado</option>
-                                <option value="CONCLUIDO">Concluído</option>
                                 <option value="PAGO">Pago</option>
                                 <option value="CANCELADO">Cancelado</option>
                             </select>


### PR DESCRIPTION
## Summary
- remove unused CONCLUIDO status option in Manutencao html
- get indicator totals from indicadores endpoint in manutencao.js
- drop CONCLUIDO mappings from JS charts and badges

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*