### PR TITLE
Fix duplicate validation in salvarManutencao

### DIFF
--- a/transport/static/js/manutencao.js
+++ b/transport/static/js/manutencao.js
@@ -1171,15 +1171,6 @@ function salvarManutencao() {
         saveBtn.disabled = false;
         saveBtn.innerHTML = '<i class="fas fa-save me-2"></i>Salvar';
         return;
-        if (!veiculoId) {
-            showNotification('Veículo selecionado inválido.', 'error');
-            saveBtn.disabled = false;
-            saveBtn.innerHTML = '<i class="fas fa-save me-2"></i>Salvar';
-            return;
-        }
-
- main
-
     }
 
     const formData = {


### PR DESCRIPTION
## Summary
- remove duplicate vehicle validation block from `salvarManutencao`
- clean stray `main` text

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*