### PR TITLE
Avoid unnecessary MDF-e plate loading

### DIFF
--- a/transport/templates/manutencao.html
+++ b/transport/templates/manutencao.html
@@ -12,7 +12,7 @@
 <button class="btn btn-sm btn-success" data-bs-toggle="modal" data-bs-target="#addManutencaoModal" id="btnNewManutencao">
     <i class="fas fa-plus me-1"></i>Nova Manutenção
 </button>
-<a href="{% url 'admin:transport_veiculo_add' %}" class="btn btn-sm btn-primary ms-2">
+<a href="{% url 'admin:transport_veiculo_add' %}" class="btn btn-sm btn-primary ms-2" target="_blank" rel="noopener noreferrer">
     <i class="fas fa-truck me-1"></i>Cadastrar Veículo
 </a>
 {% endblock %}


### PR DESCRIPTION
## Summary
- check vehicle list after API call
- only call `loadPlacasFromMDFe` when no vehicles or error
- open vehicle registration link in a new tab

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*