### PR TITLE
Fix vehicle modal flow in maintenance

### DIFF
--- a/transport/templates/manutencao.html
+++ b/transport/templates/manutencao.html
@@ -206,7 +206,7 @@
                                     <option value="">Selecione um veículo</option>
                                     <!-- Opções carregadas dinamicamente pelo JS -->
                                 </select>
-                                <button class="btn btn-outline-primary" type="button" id="novoVeiculoBtn" title="Novo Veículo">
+                                <button class="btn btn-outline-primary" type="button" id="novoVeiculoBtn" title="Novo Veículo" data-bs-toggle="modal" data-bs-target="#addVeiculoModal">
                                     <i class="fas fa-plus"></i>
                                 </button>
                             </div>


### PR DESCRIPTION
## Summary
- improve fallback logic when loading vehicle plates from MDFe
- ensure modal button in maintenance form opens vehicle modal

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `node --check transport/static/js/manutencao.js`