### PR TITLE
Fix vehicle modal flow and restore plate loading

### DIFF
--- a/transport/templates/manutencao.html
+++ b/transport/templates/manutencao.html
@@ -206,7 +206,8 @@
                                     <option value="">Selecione um veículo</option>
                                     <!-- Opções carregadas dinamicamente pelo JS -->
                                 </select>
-                                <button class="btn btn-outline-primary" type="button" id="novoVeiculoBtn" title="Novo Veículo">
+                                <button class="btn btn-outline-primary" type="button" id="novoVeiculoBtn" title="Novo Veículo"
+                                        data-bs-toggle="modal" data-bs-target="#addVeiculoModal">
                                     <i class="fas fa-plus"></i>
                                 </button>
                             </div>


### PR DESCRIPTION
## Summary
- restore working `loadPlacasFromMDFe` function and add missing helpers
- re-enable fallback plate loading from CT-es
- show basic plate info via `showPlateInfo`
- open vehicle modal directly via `data-bs-*` attributes in maintenance form

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `node --check transport/static/js/manutencao.js`