### PR TITLE
Fix stray token in tests

### DIFF
--- a/transport/tests.py
+++ b/transport/tests.py
@@ -11,7 +11,6 @@ from .services.parser_mdfe import parse_mdfe_completo
 from rest_framework import status
 from rest_framework.test import APITestCase, APIClient
 from rest_framework_simplejwt.tokens import RefreshToken
- main
 
 class AuthTests(APITestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- clean up stray `main` token from `transport/tests.py`

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*